### PR TITLE
Lotto system gui

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,7 +4,6 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="testRunner" value="CHOOSE_PER_TEST" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">

--- a/app/src/main/java/com/example/plannet/Entrant/EntrantLotterySystem.java
+++ b/app/src/main/java/com/example/plannet/Entrant/EntrantLotterySystem.java
@@ -1,111 +1,112 @@
-package com.example.plannet.Entrant;
-
-import com.google.firebase.firestore.FirebaseFirestore;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
-
-
-public class EntrantLotterySystem {
-
-    private final FirebaseFirestore db = FirebaseFirestore.getInstance();
-    private final EntrantManager entrantManager = EntrantManager.getInstance();
-
-    /**
-     * Randomly selects a specified number of entrants from the pending waitlist.
-     */
-    public List<String> drawParticipants(int numToSelect) {
-        List<String> pendingList = entrantManager.getPendingWaitlist();
-        Random random = new Random();
-        List<String> selectedParticipants = new ArrayList<>();
-
-        // Ensure we don't select more participants than are available
-        numToSelect = Math.min(numToSelect, pendingList.size());
-
-        // Randomly select participants without duplication
-        while (selectedParticipants.size() < numToSelect) {
-            int randomIndex = random.nextInt(pendingList.size());
-            String selectedEntrant = pendingList.get(randomIndex);
-
-            if (!selectedParticipants.contains(selectedEntrant)) {
-                selectedParticipants.add(selectedEntrant);
-            }
-        }
-
-        return selectedParticipants;
-    }
-
-    /**
-     * Processes selected participants by moving them from the pending to the accepted waitlist
-     */
-    public void processSelectedParticipants(List<String> selectedEntrants) {
-        List<String> pendingList = entrantManager.getPendingWaitlist();
-        List<String> acceptedList = entrantManager.getAcceptedWaitlist();
-
-        for (String entrantId : selectedEntrants) {
-            // Move entrant from pending to accepted list
-            pendingList.remove(entrantId);
-            acceptedList.add(entrantId);
-
-            // Update the entrant's status in Firebase
-            db.collection("entrants")
-                    .document(entrantId)
-                    .update("status", "accepted")
-                    .addOnSuccessListener(aVoid -> System.out.println("Entrant status updated to accepted: " + entrantId))
-                    .addOnFailureListener(e -> System.err.println("Error updating entrant status: " + entrantId));
-        }
-    }
-
-    /**
-     * Rejects a participant by moving them from the accepted waitlist to the rejected waitlist.
-     */
-    public void rejectParticipant(String entrantId) {
-        List<String> acceptedList = entrantManager.getAcceptedWaitlist();
-        List<String> rejectedList = entrantManager.getRejectedWaitlist();
-
-        // Move entrant from accepted to rejected list
-        acceptedList.remove(entrantId);
-        rejectedList.add(entrantId);
-
-        // Update the entrant's status in Firebase
-        db.collection("entrants")
-                .document(entrantId)
-                .update("status", "rejected")
-                .addOnSuccessListener(aVoid -> System.out.println("Entrant status updated to rejected: " + entrantId))
-                .addOnFailureListener(e -> System.err.println("Error updating entrant status: " + entrantId));
-    }
-
-    /**
-     * Redraws a single participant from the pending waitlist and moves them to the accepted waitlist.
-     *
-     * @return The newly selected participant's ID.
-     */
-    public String redrawParticipant() {
-        List<String> pendingList = entrantManager.getPendingWaitlist();
-        List<String> acceptedList = entrantManager.getAcceptedWaitlist();
-
-        if (!pendingList.isEmpty()) {
-            // Randomly select one entrant
-            Random random = new Random();
-            int randomIndex = random.nextInt(pendingList.size());
-            String entrantId = pendingList.get(randomIndex);
-
-            // Move entrant from pending to accepted list
-            pendingList.remove(entrantId);
-            acceptedList.add(entrantId);
-
-            // Update the entrant's status in Firebase
-            db.collection("entrants")
-                    .document(entrantId)
-                    .update("status", "accepted")
-                    .addOnSuccessListener(aVoid -> System.out.println("Entrant redrawn to accepted: " + entrantId))
-                    .addOnFailureListener(e -> System.err.println("Error redrawing entrant to accepted: " + entrantId));
-
-            return entrantId;
-        }
-
-        // We are done
-        return null;
-    }
-}
+//package com.example.plannet.Entrant;
+//
+//import com.google.firebase.firestore.FirebaseFirestore;
+//
+//import java.util.ArrayList;
+//import java.util.List;
+//import java.util.Random;
+//
+//// COMMENTED OUT DUE TO ERRORS! Uncomment if needed
+//
+//public class EntrantLotterySystem {
+//
+//    private final FirebaseFirestore db = FirebaseFirestore.getInstance();
+//    private final EntrantManager entrantManager = EntrantManager.getInstance();
+//
+//    /**
+//     * Randomly selects a specified number of entrants from the pending waitlist.
+//     */
+//    public List<String> drawParticipants(int numToSelect) {
+//        List<String> pendingList = entrantManager.getPendingWaitlist();
+//        Random random = new Random();
+//        List<String> selectedParticipants = new ArrayList<>();
+//
+//        // Ensure we don't select more participants than are available
+//        numToSelect = Math.min(numToSelect, pendingList.size());
+//
+//        // Randomly select participants without duplication
+//        while (selectedParticipants.size() < numToSelect) {
+//            int randomIndex = random.nextInt(pendingList.size());
+//            String selectedEntrant = pendingList.get(randomIndex);
+//
+//            if (!selectedParticipants.contains(selectedEntrant)) {
+//                selectedParticipants.add(selectedEntrant);
+//            }
+//        }
+//
+//        return selectedParticipants;
+//    }
+//
+//    /**
+//     * Processes selected participants by moving them from the pending to the accepted waitlist
+//     */
+//    public void processSelectedParticipants(List<String> selectedEntrants) {
+//        List<String> pendingList = entrantManager.getPendingWaitlist();
+//        List<String> acceptedList = entrantManager.getAcceptedWaitlist();
+//
+//        for (String entrantId : selectedEntrants) {
+//            // Move entrant from pending to accepted list
+//            pendingList.remove(entrantId);
+//            acceptedList.add(entrantId);
+//
+//            // Update the entrant's status in Firebase
+//            db.collection("entrants")
+//                    .document(entrantId)
+//                    .update("status", "accepted")
+//                    .addOnSuccessListener(aVoid -> System.out.println("Entrant status updated to accepted: " + entrantId))
+//                    .addOnFailureListener(e -> System.err.println("Error updating entrant status: " + entrantId));
+//        }
+//    }
+//
+//    /**
+//     * Rejects a participant by moving them from the accepted waitlist to the rejected waitlist.
+//     */
+//    public void rejectParticipant(String entrantId) {
+//        List<String> acceptedList = entrantManager.getAcceptedWaitlist();
+//        List<String> rejectedList = entrantManager.getRejectedWaitlist();
+//
+//        // Move entrant from accepted to rejected list
+//        acceptedList.remove(entrantId);
+//        rejectedList.add(entrantId);
+//
+//        // Update the entrant's status in Firebase
+//        db.collection("entrants")
+//                .document(entrantId)
+//                .update("status", "rejected")
+//                .addOnSuccessListener(aVoid -> System.out.println("Entrant status updated to rejected: " + entrantId))
+//                .addOnFailureListener(e -> System.err.println("Error updating entrant status: " + entrantId));
+//    }
+//
+//    /**
+//     * Redraws a single participant from the pending waitlist and moves them to the accepted waitlist.
+//     *
+//     * @return The newly selected participant's ID.
+//     */
+//    public String redrawParticipant() {
+//        List<String> pendingList = entrantManager.getPendingWaitlist();
+//        List<String> acceptedList = entrantManager.getAcceptedWaitlist();
+//
+//        if (!pendingList.isEmpty()) {
+//            // Randomly select one entrant
+//            Random random = new Random();
+//            int randomIndex = random.nextInt(pendingList.size());
+//            String entrantId = pendingList.get(randomIndex);
+//
+//            // Move entrant from pending to accepted list
+//            pendingList.remove(entrantId);
+//            acceptedList.add(entrantId);
+//
+//            // Update the entrant's status in Firebase
+//            db.collection("entrants")
+//                    .document(entrantId)
+//                    .update("status", "accepted")
+//                    .addOnSuccessListener(aVoid -> System.out.println("Entrant redrawn to accepted: " + entrantId))
+//                    .addOnFailureListener(e -> System.err.println("Error redrawing entrant to accepted: " + entrantId));
+//
+//            return entrantId;
+//        }
+//
+//        // We are done
+//        return null;
+//    }
+//}

--- a/app/src/main/java/com/example/plannet/Event/LotterySystem.java
+++ b/app/src/main/java/com/example/plannet/Event/LotterySystem.java
@@ -14,27 +14,29 @@ public class LotterySystem {
     private final FirebaseFirestore db = FirebaseFirestore.getInstance();
     /**
      * Performs a lottery draw to randomly select a number of participants from the pending waitlist.
+     * Returns a list of profiles that are selected.
+     * @param numToDraw
+     *      The number of participants to draw
+     * @param pendingWaitlist
+     *      A list of EntrantProfiles to draw from
+     * @return
+     *      A list of EntrantProfiles that are selected
      */
-    public List<EntrantProfile> drawParticipants(EventWaitlistPending pendingWaitlist, int numToDraw) {
+    public List<EntrantProfile> drawParticipants(List<EntrantProfile> pendingWaitlist, int numToDraw) {
         Random random = new Random();
 
         List<EntrantProfile> selectedParticipants = new ArrayList<>();
-        List<EntrantProfile> waitingList = pendingWaitlist.getWaitlistEntrants();// Get the pending entreants from the waiting list
 
         // Ensure we do not draw more participants than the number of entrants in the waiting list
-        if (numToDraw > waitingList.size()) {
-            numToDraw = waitingList.size();
+        if (numToDraw > pendingWaitlist.size()) {
+            numToDraw = pendingWaitlist.size();
         }
 
         // Randomly select participants until we have draw the number of people we want
         while (selectedParticipants.size() < numToDraw) {
-            int randomIndex = random.nextInt(waitingList.size());
-            EntrantProfile selectedEntrant = waitingList.get(randomIndex);
-
-            //check the selected list to make sure there is no duplication
-            if (!selectedParticipants.contains(selectedEntrant)) {
-                selectedParticipants.add(selectedEntrant);
-            }
+            int randomIndex = random.nextInt(pendingWaitlist.size());
+            EntrantProfile selectedEntrant = pendingWaitlist.remove(randomIndex);  // .remove is like .pop() in other languages
+            selectedParticipants.add(selectedEntrant);
         }
 
         return selectedParticipants;
@@ -109,7 +111,8 @@ public class LotterySystem {
         // Ensure there are entrants left in the pending list
         //if there are still entrants left, repeat the steps of adding and removing entrants
         if (!pendingList.isEmpty()) {
-            EntrantProfile newParticipant = drawParticipants(pendingWaitlist, 1).get(0);// Randomly select one entrant
+            // Jon changed pendingWaitlist on this line to PendingList. It was causing errors.
+            EntrantProfile newParticipant = drawParticipants(pendingList, 1).get(0);// Randomly select one entrant
             chosenWaitlist.addChosenEntrant(newParticipant);
             pendingWaitlist.removeEntrant(newParticipant);
 

--- a/app/src/main/java/com/example/plannet/ui/entrantprofile/entrantViewEventFragment.java
+++ b/app/src/main/java/com/example/plannet/ui/entrantprofile/entrantViewEventFragment.java
@@ -309,6 +309,8 @@ public class entrantViewEventFragment extends Fragment {
 }
 
 
+
+
 //    private void showAcceptDeclineDialog(String eventId, String userId, Button actionButton) {
 //        if (eventId == null || userId == null) {
 //            Toast.makeText(getContext(), "Missing event or user ID.", Toast.LENGTH_SHORT).show();

--- a/app/src/main/java/com/example/plannet/ui/orghome/OrganizerHomeFragment.java
+++ b/app/src/main/java/com/example/plannet/ui/orghome/OrganizerHomeFragment.java
@@ -91,9 +91,8 @@ public class OrganizerHomeFragment extends Fragment {
 
 
         binding.buttonDraw.setOnClickListener(v -> {
-            // Future navigation reference
-            // navController.navigate(R.id.action_homeFragment_to_drawFragment);
-            // UPDATE -- instead of a whole new fragment, we could just show a dialog for this (much easier!)
+            NavController navController = Navigation.findNavController(v);
+            navController.navigate(R.id.action_navigation_orghome_to_organizerLotteryManager);
         });
 
         binding.buttonSwitch.setOnClickListener(v -> {

--- a/app/src/main/java/com/example/plannet/ui/orglottery/OrganizerLotteryManager.java
+++ b/app/src/main/java/com/example/plannet/ui/orglottery/OrganizerLotteryManager.java
@@ -1,0 +1,72 @@
+package com.example.plannet.ui.orglottery;
+
+import android.os.Bundle;
+import android.provider.Settings;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
+import androidx.navigation.NavController;
+import androidx.navigation.Navigation;
+
+import com.example.plannet.ArrayAdapters.OrganizerEventListArrayAdapter;
+import com.example.plannet.Event.Event;
+import com.example.plannet.FirebaseConnector;
+import com.example.plannet.R;
+import com.example.plannet.databinding.FragmentOrganizerLotteryManagerBinding;
+
+public class OrganizerLotteryManager extends Fragment {
+    /**
+     * this is where the organizer chooses one of their events to run the lottery on
+     */
+    private FragmentOrganizerLotteryManagerBinding binding;
+    private FirebaseConnector dbConnector = new FirebaseConnector();
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater,
+                             ViewGroup container, Bundle savedInstanceState) {
+        binding = FragmentOrganizerLotteryManagerBinding.inflate(inflater, container, false);
+        View root = binding.getRoot();
+        String userID1 = Settings.Secure.getString(requireContext().getContentResolver(), Settings.Secure.ANDROID_ID);
+
+        // Fetch created Events from Firebase using callback
+        dbConnector.getOrganizerEventsList(userID1, events -> {
+            // Update the adapter with fetched events
+            OrganizerEventListArrayAdapter adapter = new OrganizerEventListArrayAdapter(getContext(), events);
+            binding.eventList.setAdapter(adapter);
+        });
+
+        // Listener for clicking an element of the list
+        binding.eventList.setOnItemClickListener((adapterView, view, i, l) -> {
+            // Get the selected event
+            Event clickedEvent = (Event) adapterView.getItemAtPosition(i);
+
+            // Create a bundle to access the event from the new page
+            Bundle passedEventBundle = new Bundle();
+            Log.d("LotteryManager", "Bundling event with name: " + clickedEvent.getEventName());
+            passedEventBundle.putSerializable("event", clickedEvent);
+
+
+            // Navigate to the new fragment
+            NavController navController = Navigation.findNavController(view);
+            // Don't forget to pass the bundle!
+            navController.navigate(R.id.action_organizerLotteryManager_to_organizerRunLottery, passedEventBundle);
+        });
+
+        // Back arrow
+        binding.backArrow.setOnClickListener(v -> {
+            NavController navController = Navigation.findNavController(v);
+            navController.navigate(R.id.action_organizerLotteryManager_to_navigation_orghome);
+        });
+
+        return root;
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        binding = null;
+    }
+}

--- a/app/src/main/java/com/example/plannet/ui/orglottery/OrganizerRunLottery.java
+++ b/app/src/main/java/com/example/plannet/ui/orglottery/OrganizerRunLottery.java
@@ -1,0 +1,145 @@
+package com.example.plannet.ui.orglottery;
+
+import android.os.Bundle;
+import android.provider.Settings;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import androidx.navigation.NavController;
+import androidx.navigation.Navigation;
+
+import com.example.plannet.Entrant.EntrantProfile;
+import com.example.plannet.Event.Event;
+import com.example.plannet.Event.LotterySystem;
+import com.example.plannet.FirebaseConnector;
+import com.example.plannet.R;
+import com.example.plannet.databinding.FragmentOrganizerRunLotteryBinding;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class OrganizerRunLottery extends Fragment {
+    /**
+     * this is where the organizer runs the lottery
+     */
+    private FragmentOrganizerRunLotteryBinding binding;
+    private Event event = null;  // Default null for error catching
+    private FirebaseConnector dbConnector = new FirebaseConnector();
+
+    /**
+     * onCreateView for what happens when the view is first created.
+     *
+     * @param inflater The LayoutInflater object that can be used to inflate
+     * any views in the fragment,
+     * @param container If non-null, this is the parent view that the fragment's
+     * UI should be attached to.  The fragment should not add the view itself,
+     * but this can be used to generate the LayoutParams of the view.
+     * @param savedInstanceState If non-null, this fragment is being re-constructed
+     * from a previous saved state as given here.
+     *
+     * @return
+     *      the View
+     */
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        binding = FragmentOrganizerRunLotteryBinding.inflate(inflater, container, false);
+        View root = binding.getRoot();
+
+        LotterySystem lotto = new LotterySystem();
+
+        Log.d("OrganizerRunLottery", "Arguments received: " + getArguments());
+        if (getArguments() != null){
+            Log.d("OrganizerRunLottery", "Arguments found in bundle.");
+            // Retrieve the argument we passed in the bundle before coming here
+            event = (Event) getArguments().getSerializable("event");
+
+            if (event != null) {
+                Log.d("OrganizerRunLottery", "Event found with name: " + event.getEventName());
+                binding.eventName.setText("Event: " + event.getEventName());
+            }
+        }
+        else {
+            Log.e("OrganizerRunLottery", "No arguments recieved. Event/bundle did not pass correctly from previous fragment.");
+            binding.title.setText("ERROR!");
+            Toast.makeText(getContext(), "Error passing event. Please click the back arrow.", Toast.LENGTH_SHORT).show();
+        }
+
+        // button listener for back button
+        binding.backArrow.setOnClickListener(v -> {
+            if (binding != null) {
+                try {
+                    NavController navController = Navigation.findNavController(v);
+                    navController.navigate(R.id.action_organizerRunLottery_to_organizerLotteryManager);
+                } catch (Exception e) {
+                    Log.e("OrganizerRunLottery", "Error navigating back", e);
+                }
+            } else {
+                Log.e("OrganizerRunLottery", "Binding is null in back arrow listener.");
+            }
+        });
+
+        // button listener for clicking "Entrants" button
+        binding.drawButton.setOnClickListener(v -> {
+            String howMany = binding.editTextNumber.getText().toString();
+            if (howMany.isEmpty()){
+                Toast.makeText(getContext(), "Please enter an amount.", Toast.LENGTH_SHORT).show();
+            } else if (Integer.parseInt(howMany) <= 0) {
+                Toast.makeText(getContext(), "Please enter a positive number.", Toast.LENGTH_SHORT).show();
+            }
+            else if (event != null) {
+                dbConnector.getEventWaitlistEntrants(event.getEventID(), "pending", pending -> {
+                    if (pending.size() < Integer.parseInt(howMany)) {
+                        Toast.makeText(getContext(), "Total waitlist length: " + pending.size() + ". Please enter at most " + pending.size() + ".", Toast.LENGTH_SHORT).show();
+                    }
+                    else {
+                        List<EntrantProfile> selected = new ArrayList<>(lotto.drawParticipants(pending, Integer.parseInt(howMany)));
+                        for (EntrantProfile entrant: selected){
+                            removeFromPending(entrant, event);
+                            addToChosen(entrant, event);
+                        }
+                    }
+                });
+            }
+            if (event != null) {
+                // Bundle the event again to send to new page
+                Bundle passedEventBundle = new Bundle();
+                Log.d("Organizer View Event", "Bundling event with name: " + event.getEventName());
+                passedEventBundle.putSerializable("event", event);
+
+                // Navigate to the new fragment
+                NavController navController = Navigation.findNavController(v);
+                // Don't forget to pass the bundle!
+                navController.navigate(R.id.action_organizerViewEventFragment_to_organizerViewEntrantsFragment, passedEventBundle);
+            }
+            else {
+                // Somehow the user got to this page and the event did not bundle
+                Toast.makeText(getContext(), "Error passing event. Please click the back arrow.", Toast.LENGTH_SHORT).show();
+            }
+        });
+
+        return root;
+    }
+
+    private void addToChosen(EntrantProfile entrant, Event event) {
+        // leaving errors here so we see it
+        THIS NEEDS TO BE IMPLEMENTED
+    }
+
+    private void removeFromPending(EntrantProfile entrant, Event event) {
+        // leaving errors here so we see it
+        THIS NEEDS TO BE IMPLEMENTED
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        binding = null;
+    }
+}

--- a/app/src/main/java/com/example/plannet/ui/orglottery/OrganizerRunLottery.java
+++ b/app/src/main/java/com/example/plannet/ui/orglottery/OrganizerRunLottery.java
@@ -101,22 +101,14 @@ public class OrganizerRunLottery extends Fragment {
                     else {
                         List<EntrantProfile> selected = new ArrayList<>(lotto.drawParticipants(pending, Integer.parseInt(howMany)));
                         for (EntrantProfile entrant: selected){
-                            removeFromPending(entrant, event);
-                            addToChosen(entrant, event);
+                            dbConnector.moveToWaitlist(event.getEventID(), entrant.getUserId());
                         }
+                        Toast.makeText(getContext(), "Success! " + selected.size() + "Entrants chosen.", Toast.LENGTH_SHORT).show();
+                        // Navigate back to home
+                        NavController navController = Navigation.findNavController(v);
+                        navController.navigate(R.id.action_organizerRunLottery_to_navigation_orghome);
                     }
                 });
-            }
-            if (event != null) {
-                // Bundle the event again to send to new page
-                Bundle passedEventBundle = new Bundle();
-                Log.d("Organizer View Event", "Bundling event with name: " + event.getEventName());
-                passedEventBundle.putSerializable("event", event);
-
-                // Navigate to the new fragment
-                NavController navController = Navigation.findNavController(v);
-                // Don't forget to pass the bundle!
-                navController.navigate(R.id.action_organizerViewEventFragment_to_organizerViewEntrantsFragment, passedEventBundle);
             }
             else {
                 // Somehow the user got to this page and the event did not bundle
@@ -125,16 +117,6 @@ public class OrganizerRunLottery extends Fragment {
         });
 
         return root;
-    }
-
-    private void addToChosen(EntrantProfile entrant, Event event) {
-        // leaving errors here so we see it
-        THIS NEEDS TO BE IMPLEMENTED
-    }
-
-    private void removeFromPending(EntrantProfile entrant, Event event) {
-        // leaving errors here so we see it
-        THIS NEEDS TO BE IMPLEMENTED
     }
 
     @Override

--- a/app/src/main/res/layout/fragment_organizer_lottery_manager.xml
+++ b/app/src/main/res/layout/fragment_organizer_lottery_manager.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    tools:context=".ui.orglottery.OrganizerLotteryManager"
     android:background="@drawable/background_gradient">
 
     <TextView
@@ -51,9 +52,22 @@
         android:layout_marginLeft="10dp"
         android:layout_marginRight="10dp"
         android:layout_marginBottom="100dp"
+        android:divider="@drawable/line_separator"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/event_name"
         android:background="@drawable/listview_border"/>
+
+    <ImageView
+        android:id="@+id/back_arrow"
+        android:layout_width="50dp"
+        android:layout_height="50dp"
+        app:layout_constraintBottom_toBottomOf="@+id/title"
+        app:layout_constraintEnd_toStartOf="@+id/title"
+        app:layout_constraintHorizontal_bias="0.2"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="1.0"
+        app:srcCompat="@drawable/back_arrow" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_organizer_lottery_manager.xml
+++ b/app/src/main/res/layout/fragment_organizer_lottery_manager.xml
@@ -70,4 +70,14 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_bias="1.0"
         app:srcCompat="@drawable/back_arrow" />
+
+    <ImageView
+        android:id="@+id/listview_border"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="@id/event_list"
+        app:layout_constraintTop_toTopOf="@id/event_list"
+        app:layout_constraintEnd_toEndOf="@id/event_list"
+        app:layout_constraintStart_toStartOf="@id/event_list"
+        android:src="@drawable/listview_border" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_organizer_notification_manager.xml
+++ b/app/src/main/res/layout/fragment_organizer_notification_manager.xml
@@ -59,4 +59,14 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/event_name"
         android:background="@drawable/listview_border"/>
+
+    <ImageView
+        android:id="@+id/listview_border"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="@id/event_list"
+        app:layout_constraintTop_toTopOf="@id/event_list"
+        app:layout_constraintEnd_toEndOf="@id/event_list"
+        app:layout_constraintStart_toStartOf="@id/event_list"
+        android:src="@drawable/listview_border" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_organizer_run_lottery.xml
+++ b/app/src/main/res/layout/fragment_organizer_run_lottery.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    tools:context=".ui.orglottery.OrganizerRunLottery"
     android:background="@drawable/background_gradient">
 
     <TextView
@@ -80,21 +81,6 @@
         app:layout_constraintHorizontal_bias="0.1"
         app:layout_constraintStart_toStartOf="@+id/purple_box"
         app:layout_constraintTop_toTopOf="@+id/purple_box"
-        app:layout_constraintBottom_toTopOf="@id/checkbox_add_chosen"/>
-
-    <CheckBox
-        android:id="@+id/checkbox_add_chosen"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:buttonTint="@color/buttonPurple"
-        android:fontFamily="@font/poppins"
-        android:text="Add to &quot;Chosen&quot; list"
-        android:textColor="@color/white"
-        android:textSize="16sp"
-        android:textStyle="bold"
-        app:layout_constraintEnd_toEndOf="@+id/purple_box"
-        app:layout_constraintStart_toStartOf="@+id/purple_box"
-        app:layout_constraintTop_toBottomOf="@+id/amount_prompt"
         app:layout_constraintBottom_toTopOf="@id/clarification"/>
 
     <TextView
@@ -102,12 +88,12 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:fontFamily="@font/poppins"
-        android:text="Entrants will be chosen from current waiting list."
+        android:text="Entrants will be chosen from current waiting list.\n\nChosen entrants will be removed from pending."
         android:textColor="@color/white"
         android:textSize="16sp"
         app:layout_constraintEnd_toEndOf="@+id/purple_box"
         app:layout_constraintStart_toStartOf="@+id/purple_box"
-        app:layout_constraintTop_toBottomOf="@+id/checkbox_add_chosen"
+        app:layout_constraintTop_toBottomOf="@+id/amount_prompt"
         app:layout_constraintBottom_toTopOf="@id/draw_button"/>
 
     <EditText
@@ -130,5 +116,15 @@
         app:layout_constraintStart_toEndOf="@+id/amount_prompt"
         app:layout_constraintTop_toTopOf="@+id/amount_prompt" />
 
-
+    <ImageView
+        android:id="@+id/back_arrow"
+        android:layout_width="50dp"
+        android:layout_height="50dp"
+        app:layout_constraintBottom_toBottomOf="@+id/title"
+        app:layout_constraintEnd_toStartOf="@+id/title"
+        app:layout_constraintHorizontal_bias="0.2"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="1.0"
+        app:srcCompat="@drawable/back_arrow" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/mobile_navigation.xml
+++ b/app/src/main/res/navigation/mobile_navigation.xml
@@ -246,6 +246,9 @@
         <action
             android:id="@+id/action_organizerRunLottery_to_organizerLotteryManager"
             app:destination="@id/organizerLotteryManager" />
+        <action
+            android:id="@+id/action_organizerRunLottery_to_navigation_orghome"
+            app:destination="@id/navigation_orghome" />
     </fragment>
 
 

--- a/app/src/main/res/navigation/mobile_navigation.xml
+++ b/app/src/main/res/navigation/mobile_navigation.xml
@@ -19,6 +19,9 @@
         <action
             android:id="@+id/action_home_to_admin"
             app:destination="@id/navigation_adminhome" />
+        <action
+            android:id="@+id/action_navigation_orghome_to_organizerLotteryManager"
+            app:destination="@id/organizerLotteryManager" />
 
     </fragment>
 
@@ -222,6 +225,27 @@
         <action
             android:id="@+id/action_adminHome_to_userMode"
             app:destination="@id/navigation_entranthome" />
+    </fragment>
+    <fragment
+        android:id="@+id/organizerLotteryManager"
+        android:name="com.example.plannet.ui.orglottery.OrganizerLotteryManager"
+        android:label="fragment_organizer_lottery_manager"
+        tools:layout="@layout/fragment_organizer_lottery_manager" >
+        <action
+            android:id="@+id/action_organizerLotteryManager_to_organizerRunLottery"
+            app:destination="@id/organizerRunLottery" />
+        <action
+            android:id="@+id/action_organizerLotteryManager_to_navigation_orghome"
+            app:destination="@id/navigation_orghome" />
+    </fragment>
+    <fragment
+        android:id="@+id/organizerRunLottery"
+        android:name="com.example.plannet.ui.orglottery.OrganizerRunLottery"
+        android:label="fragment_organizer_run_lottery"
+        tools:layout="@layout/fragment_organizer_run_lottery" >
+        <action
+            android:id="@+id/action_organizerRunLottery_to_organizerLotteryManager"
+            app:destination="@id/organizerLotteryManager" />
     </fragment>
 
 


### PR DESCRIPTION
we still need to set up:
- US 02.06.04 As an organizer I want to cancel entrants that did not sign up for the event
^ When an organizer clicks on a "chosen" entrant in their event list, their profile page should have a "cancel" button that moves them to the cancelled list. This should be possible using the function FirebaseConnector.moveToWaitlist, pretty straightforward (i will set this up in a few hours if yall want)

- Edit this lottery system I made to make sure that the length of (the number they want to draw) + the existing size of chosen_waitlist + the existing size of accepted_waitlist is greater than maxEntrants, make a toast popup if not and do not allow them to draw more entrants than maxeventlist
- check other user stories for what still needs to be done